### PR TITLE
Add support for pre-body declarations in function directives

### DIFF
--- a/src/type/function.rs
+++ b/src/type/function.rs
@@ -42,6 +42,16 @@ pub struct FuncFunctionDirective {
     /// Example:
     /// .func foo (.reg .b32 N, .reg .f64 dbl) .noreturn { ... }
     pub directives: Vec<FuncFunctionHeaderDirective>,
+    /// Pre-body declarations (.reg, .local, .shared, .param) that appear between
+    /// the function header and the body. These are allowed by PTX but must appear
+    /// before the opening brace.
+    ///
+    /// Example:
+    /// .func foo()
+    ///     .reg .b32 %r0;
+    ///     .local .b8 stack[16];
+    /// { ... }
+    pub pre_body_declarations: Vec<StatementDirective>,
     /// Optional function body. Without body represents a function prototype.
     pub body: Option<FunctionBody>,
     pub span: Span,

--- a/src/unparser/function.rs
+++ b/src/unparser/function.rs
@@ -690,6 +690,11 @@ impl PtxUnparser for FuncFunctionDirective {
         tokens.push(PtxToken::LParen);
         unparse_param_list(tokens, &self.params, spaced);
         tokens.push(PtxToken::RParen);
+        // Emit pre-body declarations (.reg, .local, .shared, .param) before the body
+        for decl in &self.pre_body_declarations {
+            push_newline(tokens, spaced);
+            decl.unparse_tokens_mode(tokens, spaced);
+        }
         match &self.body {
             Some(body) => body.unparse_tokens_mode(tokens, spaced),
             None => {

--- a/tests/mini_step64.rs
+++ b/tests/mini_step64.rs
@@ -208,6 +208,7 @@ fn expected_module() -> Module {
                         span: span!(0..0),
                     }],
                     directives: vec![],
+                    pre_body_declarations: vec![],
                     body: Some(FunctionBody {
                         statements: vec![
                             reg("%r0", "b32"),


### PR DESCRIPTION
PTX allows .reg, .local, .shared, and .param declarations to appear between the function header and the opening brace. This is valid PTX:

```ptx
.func foo()
    .reg .pred %p0;
{
}
```

This commit adds:
- pre_body_declarations field to FuncFunctionDirective
- Parser support for these declarations after header directives
- Unparser support to emit them before the function body