### PR TITLE
Support parenthesized return spec in callprototype

### DIFF
--- a/src/pretty_print/function.rs
+++ b/src/pretty_print/function.rs
@@ -393,7 +393,7 @@ impl TreeDisplay for CallPrototypeDirective {
             "CallPrototypeDirective [{}]",
             f.format_raw(self.span, source)
         ))?;
-        f.field_option(false, "return_param", &self.return_param, source)?;
+        f.field(false, "return_spec", &format!("{:?}", self.return_spec))?;
         f.field_vec(false, "params", &self.params, source)?;
         f.field(false, "noreturn", &self.noreturn.to_string())?;
         match self.abi_preserve {

--- a/src/type/function.rs
+++ b/src/type/function.rs
@@ -444,6 +444,25 @@ pub struct CallTargetsDirective {
     pub span: Span,
 }
 
+/// Return specification for a `.callprototype` directive.
+///
+/// PTX supports two syntax forms for the return spec:
+/// - Bare: `.callprototype _ (params)` or `.callprototype .param .type name (params)`
+/// - Parenthesized: `.callprototype (_) _ (params)` or `.callprototype (.param .type name) _ (params)`
+///
+/// The parenthesized form includes an explicit `_` function identifier placeholder.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum CallPrototypeReturnSpec {
+    /// Bare underscore: `.callprototype _ ...`
+    BareUnderscore,
+    /// Bare parameter: `.callprototype .param .type name ...`
+    BareParam(ParameterDirective),
+    /// Parenthesized underscore: `.callprototype (_) _ ...`
+    ParenUnderscore,
+    /// Parenthesized parameter: `.callprototype (.param .type name) _ ...`
+    ParenParam(ParameterDirective),
+}
+
 /// Structured representation of a `.callprototype` directive.
 ///
 /// Syntax:
@@ -457,7 +476,7 @@ pub struct CallTargetsDirective {
 ///     label: .callprototype (ret-param) _ (param-list) {.abi_preserve N} {.abi_preserve_control N};
 #[derive(Debug, Clone, PartialEq, Spanned, Serialize)]
 pub struct CallPrototypeDirective {
-    pub return_param: Option<ParameterDirective>,
+    pub return_spec: CallPrototypeReturnSpec,
     pub params: Vec<ParameterDirective>,
     pub noreturn: bool,
     pub abi_preserve: Option<u32>,

--- a/src/type/mod.rs
+++ b/src/type/mod.rs
@@ -36,12 +36,12 @@ pub use module::{
 
 // Re-export function types
 pub use function::{
-    AliasFunctionDirective, BranchTargetsDirective, CallPrototypeDirective, CallTargetsDirective,
-    DwarfDirective, DwarfDirectiveKind, EntryFunctionDirective, EntryFunctionHeaderDirective,
-    FuncFunctionDirective, FuncFunctionHeaderDirective, FunctionBody, FunctionDim,
-    FunctionStatement, LocationDirective, LocationInlinedAt, PragmaDirective, PragmaDirectiveKind,
-    RegisterDirective, RegisterTarget, SectionDirective, SectionEntry, StatementDirective,
-    StatementSectionDirectiveLine,
+    AliasFunctionDirective, BranchTargetsDirective, CallPrototypeDirective,
+    CallPrototypeReturnSpec, CallTargetsDirective, DwarfDirective, DwarfDirectiveKind,
+    EntryFunctionDirective, EntryFunctionHeaderDirective, FuncFunctionDirective,
+    FuncFunctionHeaderDirective, FunctionBody, FunctionDim, FunctionStatement, LocationDirective,
+    LocationInlinedAt, PragmaDirective, PragmaDirectiveKind, RegisterDirective, RegisterTarget,
+    SectionDirective, SectionEntry, StatementDirective, StatementSectionDirectiveLine,
 };
 
 // Re-export variable types

--- a/src/unparser/function.rs
+++ b/src/unparser/function.rs
@@ -374,14 +374,36 @@ impl PtxUnparser for StatementDirective {
             StatementDirective::CallPrototype { directive, .. } => {
                 push_directive(tokens, "callprototype");
                 push_space(tokens, spaced);
-                if let Some(ret) = &directive.return_param {
-                    unparse_param(tokens, ret, spaced);
-                } else {
-                    push_identifier(tokens, "_");
+
+                match &directive.return_spec {
+                    CallPrototypeReturnSpec::BareUnderscore => {
+                        push_identifier(tokens, "_");
+                    }
+                    CallPrototypeReturnSpec::BareParam(param) => {
+                        unparse_param(tokens, param, spaced);
+                    }
+                    CallPrototypeReturnSpec::ParenUnderscore => {
+                        tokens.push(PtxToken::LParen);
+                        push_identifier(tokens, "_");
+                        tokens.push(PtxToken::RParen);
+                        push_space(tokens, spaced);
+                        push_identifier(tokens, "_");
+                    }
+                    CallPrototypeReturnSpec::ParenParam(param) => {
+                        tokens.push(PtxToken::LParen);
+                        unparse_param(tokens, param, spaced);
+                        tokens.push(PtxToken::RParen);
+                        push_space(tokens, spaced);
+                        push_identifier(tokens, "_");
+                    }
                 }
+
+                // Parameter list
+                push_space(tokens, spaced);
                 tokens.push(PtxToken::LParen);
                 unparse_param_list(tokens, &directive.params, spaced);
                 tokens.push(PtxToken::RParen);
+
                 if directive.noreturn {
                     push_space(tokens, spaced);
                     push_directive(tokens, "noreturn");

--- a/tests/mini_step64.rs
+++ b/tests/mini_step64.rs
@@ -4,13 +4,13 @@ use std::fs;
 
 use ptx_parser::r#type::{
     AddressSize, AddressSizeDirective, BranchTargetsDirective, CallPrototypeDirective,
-    CallTargetsDirective, CodeLinkage, DataLinkage, DataType, EntryFunctionDirective,
-    FileDirective, FuncFunctionDirective, FunctionBody, FunctionStatement, FunctionSymbol,
-    GlobalInitializer, Immediate, InitializerValue, Instruction, Label, LocationDirective, Module,
-    ModuleDebugDirective, ModuleDirective, ModuleInfoDirectiveKind, ModuleVariableDirective,
-    ParameterDirective, PragmaDirective, PragmaDirectiveKind, RegisterDirective, RegisterTarget,
-    StatementDirective, TargetDirective, TargetString, VariableDirective, VariableModifier,
-    VariableSymbol, VersionDirective,
+    CallPrototypeReturnSpec, CallTargetsDirective, CodeLinkage, DataLinkage, DataType,
+    EntryFunctionDirective, FileDirective, FuncFunctionDirective, FunctionBody, FunctionStatement,
+    FunctionSymbol, GlobalInitializer, Immediate, InitializerValue, Instruction, Label,
+    LocationDirective, Module, ModuleDebugDirective, ModuleDirective, ModuleInfoDirectiveKind,
+    ModuleVariableDirective, ParameterDirective, PragmaDirective, PragmaDirectiveKind,
+    RegisterDirective, RegisterTarget, StatementDirective, TargetDirective, TargetString,
+    VariableDirective, VariableModifier, VariableSymbol, VersionDirective,
 };
 use ptx_parser::{PtxParser, PtxTokenStream, PtxUnlexer, PtxUnparser, span, tokenize};
 
@@ -330,7 +330,7 @@ fn expected_module() -> Module {
                             FunctionStatement::Directive {
                                 directive: StatementDirective::CallPrototype {
                                     directive: CallPrototypeDirective {
-                                        return_param: None,
+                                        return_spec: CallPrototypeReturnSpec::BareUnderscore,
                                         params: vec![ParameterDirective::Parameter {
                                             align: None,
                                             ty: DataType::U32 { span: span!(0..0) },


### PR DESCRIPTION
PTX allows two syntaxes for callprototype directives:
1. Bare return spec: `.callprototype RET_SPEC (params);`
2. Parenthesized return: `.callprototype (RET_SPEC) _ (params);`