### PR TITLE
Fix unparser spacing in `VariableDirective`

### DIFF
--- a/src/unparser/variable.rs
+++ b/src/unparser/variable.rs
@@ -142,12 +142,9 @@ impl PtxUnparser for VariableDirective {
             &self.attributes,
             spaced,
         );
-        if spaced {
-            if let Some(PtxToken::Space) = tokens.last() {
-                // remove trailing space if prefix was empty
-                tokens.pop();
-            }
-        }
+        // Note: We don't remove any trailing space here. The caller (e.g., ModuleVariableDirective)
+        // adds a space before us, and unparse_prefix adds spaces after each modifier. Both are needed
+        // for proper spacing in the output.
         self.ty.unparse_tokens_mode(tokens, spaced);
         push_space(tokens, spaced);
         push_identifier(tokens, &self.name.val);


### PR DESCRIPTION
The unparser was incorrectly removing the trailing space that the caller (`ModuleVariableDirective`) adds before `VariableDirective`. This caused malformed PTX like `.align 8.b8` instead of `.align 8 .b8` (note the space).

Note: not sure this is the right fix, but seems to work on my project.